### PR TITLE
feat: allow passing logger

### DIFF
--- a/handlers/Twitter.ts
+++ b/handlers/Twitter.ts
@@ -1,5 +1,6 @@
 import type EventEmitter from 'node:events';
 import Twitter, { type BearerTokenOptions, type MediaEntity, type Status, type TwitterClient } from 'twitter';
+import type { Logger } from 'winston';
 
 import toWatch from '@/resources/tweeters.json';
 import { logger } from '@/utilities';
@@ -96,6 +97,7 @@ const parseTweet = (tweets: Status[], watchable: Watchable): ParsedTweet => {
  */
 export default class TwitterCache {
   private emitter: EventEmitter;
+  private logger: Logger;
   private timeout: number;
   public clientInfoValid: boolean;
   private client?: TwitterClient;
@@ -114,6 +116,7 @@ export default class TwitterCache {
    * @param options.clientInfo - Custom Twitter client credentials
    * @param options.watchList - Custom list of Twitter accounts to watch
    * @param options.timeout - Polling interval in milliseconds
+   * @param options.logger - Custom logger instance (default: uses global logger)
    */
   constructor(
     eventEmitter: EventEmitter,
@@ -122,9 +125,11 @@ export default class TwitterCache {
       clientInfo?: Partial<BearerTokenOptions>;
       watchList?: Watchable[];
       timeout?: number;
+      logger?: Logger;
     } = {},
   ) {
     this.emitter = eventEmitter;
+    this.logger = options.logger || logger;
     this.timeout = options.timeout ?? TWITTER_TIMEOUT;
     this.lastUpdated = Date.now() - 60000;
     this.disposed = false;
@@ -159,11 +164,11 @@ export default class TwitterCache {
         this.updateInterval = setInterval(() => this.update(), this.timeout);
         this.update();
       } else {
-        logger.warn(`Twitter client not initialized... invalid token: ${clientInfo.bearer_token}`);
+        this.logger.warn(`Twitter client not initialized... invalid token: ${clientInfo.bearer_token}`);
         this.dispose();
       }
     } catch (err) {
-      logger.error(err);
+      this.logger.error(err);
       this.dispose();
     }
   }
@@ -189,12 +194,12 @@ export default class TwitterCache {
     if (this.disposed || !this.clientInfoValid) return undefined;
 
     if (!this.toWatch || this.toWatch.length === 0) {
-      logger.verbose('Not processing twitter, no data to watch.');
+      this.logger.verbose('Not processing twitter, no data to watch.');
       return undefined;
     }
 
     if (!this.client) {
-      logger.verbose('Not processing twitter, no client to connect.');
+      this.logger.verbose('Not processing twitter, no client to connect.');
       return undefined;
     }
 
@@ -208,7 +213,7 @@ export default class TwitterCache {
    * @returns Tweets
    */
   private async getParseableData(): Promise<ParsedTweet[] | undefined> {
-    logger.silly('Starting Twitter update...');
+    this.logger.silly('Starting Twitter update...');
     const parsedData: ParsedTweet[] = [];
     try {
       await Promise.all(
@@ -241,10 +246,10 @@ export default class TwitterCache {
    */
   private onError(error: unknown): void {
     if (Array.isArray(error) && error[0] && error[0].code === 32) {
-      logger.info('wiping twitter client data, could not authenticate...');
+      this.logger.info('wiping twitter client data, could not authenticate...');
       this.dispose();
     } else {
-      logger.debug(JSON.stringify(error));
+      this.logger.debug(JSON.stringify(error));
     }
   }
 
@@ -272,6 +277,6 @@ export default class TwitterCache {
     }
     this.client = undefined;
     this.clientInfoValid = false;
-    logger.verbose('Twitter polling stopped and resources cleaned up');
+    this.logger.verbose('Twitter polling stopped and resources cleaned up');
   }
 }

--- a/handlers/Twitter.ts
+++ b/handlers/Twitter.ts
@@ -194,12 +194,12 @@ export default class TwitterCache {
     if (this.disposed || !this.clientInfoValid) return undefined;
 
     if (!this.toWatch || this.toWatch.length === 0) {
-      this.logger.verbose('Not processing twitter, no data to watch.');
+      this.logger.debug('Not processing twitter, no data to watch.');
       return undefined;
     }
 
     if (!this.client) {
-      this.logger.verbose('Not processing twitter, no client to connect.');
+      this.logger.debug('Not processing twitter, no client to connect.');
       return undefined;
     }
 
@@ -213,7 +213,7 @@ export default class TwitterCache {
    * @returns Tweets
    */
   private async getParseableData(): Promise<ParsedTweet[] | undefined> {
-    this.logger.silly('Starting Twitter update...');
+    this.logger.debug('Starting Twitter update...');
     const parsedData: ParsedTweet[] = [];
     try {
       await Promise.all(
@@ -277,6 +277,6 @@ export default class TwitterCache {
     }
     this.client = undefined;
     this.clientInfoValid = false;
-    this.logger.verbose('Twitter polling stopped and resources cleaned up');
+    this.logger.debug('Twitter polling stopped and resources cleaned up');
   }
 }

--- a/handlers/Worldstate.ts
+++ b/handlers/Worldstate.ts
@@ -2,6 +2,7 @@ import type EventEmitter from 'node:events';
 
 import wsData from 'warframe-worldstate-data';
 import type WorldState from 'warframe-worldstate-parser';
+import type { Logger } from 'winston';
 import parseNew from '@/handlers/events/parse';
 import type { BaseEventData, EventPacket } from '@/handlers/events/types';
 import { externalCron, kuvaUrl, sentientUrl, worldstateCron, worldstateUrl } from '@/resources/config';
@@ -24,6 +25,7 @@ interface ParseEventsPacket {
 export default class Worldstate {
   #emitter: EventEmitter;
   #locale?: string;
+  #logger: Logger;
   #worldStates: Record<string, WSCache> = {};
   #wsRawCache?: Cache;
   #kuvaCache?: Cache;
@@ -32,21 +34,28 @@ export default class Worldstate {
   /**
    * Set up listening for specific platform and locale if provided.
    * @param eventEmitter - Emitter to push new worldstate events to
-   * @param locale - Locale (actually just language) to watch
+   * @param options - Configuration options
    */
-  constructor(eventEmitter: EventEmitter, locale?: string) {
+  constructor(
+    eventEmitter: EventEmitter,
+    options: {
+      locale?: string;
+      logger?: Logger;
+    } = {},
+  ) {
     this.#emitter = eventEmitter;
-    this.#locale = locale;
-    logger.debug('starting up worldstate listener...');
-    if (locale) {
-      logger.debug(`only listening for ${locale}...`);
+    this.#locale = options.locale;
+    this.#logger = options.logger || logger;
+    this.#logger.debug('starting up worldstate listener...');
+    if (options.locale) {
+      this.#logger.debug(`only listening for ${options.locale}...`);
     }
   }
 
   async init(): Promise<void> {
-    this.#wsRawCache = await Cache.make(worldstateUrl, worldstateCron);
-    this.#kuvaCache = await Cache.make(kuvaUrl, externalCron);
-    this.#sentientCache = await Cache.make(sentientUrl, externalCron);
+    this.#wsRawCache = await Cache.make(worldstateUrl, worldstateCron, this.#logger);
+    this.#kuvaCache = await Cache.make(kuvaUrl, externalCron, this.#logger);
+    this.#sentientCache = await Cache.make(sentientUrl, externalCron, this.#logger);
 
     await this.setUpRawEmitters();
     this.setupParsedEvents();
@@ -65,6 +74,7 @@ export default class Worldstate {
           kuvaCache: this.#kuvaCache!,
           sentientCache: this.#sentientCache!,
           eventEmitter: this.#emitter,
+          logger: this.#logger,
         });
       }
     }
@@ -76,7 +86,7 @@ export default class Worldstate {
 
     /* when the raw emits happen, parse them and store them on parsed worldstate caches */
     this.#emitter.on('ws:update:raw', ({ data }: { data: string }) => {
-      logger.debug('ws:update:raw - updating locales data');
+      this.#logger.debug('ws:update:raw - updating locales data');
       locales.forEach((locale) => {
         if (!this.#locale || this.#locale === locale) {
           this.#worldStates[locale].data = data;
@@ -140,9 +150,9 @@ export default class Worldstate {
    * @param packet - Data packet to emit
    */
   emit(id: string, packet: EventPacket): void {
-    if (debugEvents.includes(packet.key)) logger.warn(packet.key);
+    if (debugEvents.includes(packet.key)) this.#logger.warn(packet.key);
 
-    logger.debug(`ws:update:event - emitting ${packet.id}`);
+    this.#logger.debug(`ws:update:event - emitting ${packet.id}`);
     delete packet.cycleStart;
     this.#emitter.emit(id, packet);
   }
@@ -154,7 +164,7 @@ export default class Worldstate {
    * @throws When the platform or locale aren't tracked and aren't updated
    */
   get(language = 'en'): WorldState | undefined {
-    logger.debug(`getting worldstate ${language}...`);
+    this.#logger.debug(`getting worldstate ${language}...`);
     if (this.#worldStates?.[language]) {
       return this.#worldStates?.[language]?.data;
     }

--- a/index.ts
+++ b/index.ts
@@ -2,16 +2,17 @@ import EventEmitter from 'node:events';
 
 import type { RSSItem } from 'rss-feed-emitter';
 import type WorldState from 'warframe-worldstate-parser';
-
+import type { Logger } from 'winston';
 import RSS from '@/handlers/RSS';
 import Twitter from '@/handlers/Twitter';
 import Worldstate from '@/handlers/Worldstate';
 import { FEATURES } from '@/resources/config';
-import { logger } from '@/utilities';
+import { logger, setLogger } from '@/utilities';
 
 interface WorldstateEmitterOptions {
   locale?: string;
   features?: string[];
+  logger?: Logger;
 }
 
 interface RssFeedItem {
@@ -53,9 +54,13 @@ export default class WorldstateEmitter extends EventEmitter {
   #worldstate?: Worldstate;
   #twitter?: Twitter;
   #rss?: RSS;
+  #logger?: Logger;
 
-  static async make({ locale, features }: WorldstateEmitterOptions = {}): Promise<WorldstateEmitter> {
-    const emitter = new WorldstateEmitter({ locale });
+  static async make({ locale, features, logger: upLogger }: WorldstateEmitterOptions = {}): Promise<WorldstateEmitter> {
+    if (upLogger) {
+      setLogger(upLogger);
+    }
+    const emitter = new WorldstateEmitter({ locale, logger: upLogger });
     await emitter.#init(features?.length ? features : FEATURES);
     return emitter;
   }
@@ -64,24 +69,25 @@ export default class WorldstateEmitter extends EventEmitter {
    * Pull in and instantiate emitters
    * @param options - Configuration options
    */
-  constructor({ locale }: WorldstateEmitterOptions = {}) {
+  constructor({ locale, logger: uLogger }: WorldstateEmitterOptions = {}) {
     super();
     this.#locale = locale;
+    this.#logger = uLogger || logger;
   }
 
   async #init(features: string[]): Promise<void> {
     if (features.includes('rss')) {
-      this.#rss = new RSS(this);
+      this.#rss = new RSS(this, { logger: this.#logger });
     }
     if (features.includes('worldstate')) {
-      this.#worldstate = new Worldstate(this, this.#locale);
+      this.#worldstate = new Worldstate(this, { locale: this.#locale, logger: this.#logger });
       await this.#worldstate.init();
     }
     if (features.includes('twitter')) {
-      this.#twitter = new Twitter(this);
+      this.#twitter = new Twitter(this, { logger: this.#logger });
     }
 
-    logger.silly('hey look, i started up...');
+    this.#logger!.silly('hey look, i started up...');
     this.setupLogging();
   }
 
@@ -90,17 +96,18 @@ export default class WorldstateEmitter extends EventEmitter {
    * @private
    */
   private setupLogging(): void {
-    this.on('error', logger.error);
+    const log = this.#logger!;
+    this.on('error', log.error.bind(log));
 
-    this.on('rss', (body: RssEventBody) => logger.silly(`emitted: ${body.id}`));
-    this.on('ws:update:raw', (body: WorldstateRawEventBody) => logger.silly(`emitted raw: ${body.platform}`));
+    this.on('rss', (body: RssEventBody) => log.silly(`emitted: ${body.id}`));
+    this.on('ws:update:raw', (body: WorldstateRawEventBody) => log.silly(`emitted raw: ${body.platform}`));
     this.on('ws:update:parsed', (body: WorldstateParsedEventBody) =>
-      logger.silly(`emitted parsed: ${body.platform} in ${body.language}`),
+      log.silly(`emitted parsed: ${body.platform} in ${body.language}`),
     );
     this.on('ws:update:event', (body: WorldstateEventBody) =>
-      logger.silly(`emitted event: ${body.id} ${body.platform} in ${body.language}`),
+      log.silly(`emitted event: ${body.id} ${body.platform} in ${body.language}`),
     );
-    this.on('tweet', (body: TweetEventBody) => logger.silly(`emitted: ${body.id}`));
+    this.on('tweet', (body: TweetEventBody) => log.silly(`emitted: ${body.id}`));
   }
 
   /**
@@ -151,5 +158,6 @@ export default class WorldstateEmitter extends EventEmitter {
       this.#twitter.dispose();
       this.#twitter = undefined;
     }
+    this.#logger!.debug('Emitter destroyed');
   }
 }

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -3,7 +3,7 @@
  * Configures global test environment
  */
 
-import { logger } from '../utilities';
+import { logger } from '@/utilities';
 
 // Completely silence the logger by replacing all methods with no-ops
 const noop = () => {};
@@ -11,7 +11,6 @@ logger.error = noop as never;
 logger.warn = noop as never;
 logger.info = noop as never;
 logger.http = noop as never;
-logger.verbose = noop as never;
 logger.debug = noop as never;
 logger.silly = noop as never;
 

--- a/test/specs/cronCache.spec.ts
+++ b/test/specs/cronCache.spec.ts
@@ -50,6 +50,8 @@ describe('CronCache', () => {
       const promise2 = cache.get();
 
       const [data1, data2] = await Promise.all([promise1, promise2]);
+      expect(data1).to.be.a('string');
+      expect(data2).to.be.a('string');
       expect(data1).to.equal(data2);
     });
 
@@ -59,8 +61,9 @@ describe('CronCache', () => {
       cacheInstances.push(cache);
 
       const data1 = await cache.get();
+      expect(data1).to.be.a('string');
       const data2 = await cache.get();
-
+      expect(data2).to.be.a('string');
       expect(data1).to.equal(data2);
     });
   });

--- a/test/specs/emitter.spec.ts
+++ b/test/specs/emitter.spec.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import WSEmitter from 'worldstate-emitter';
+import { createMockLogger } from '../helpers/mocks';
 
 describe('WorldstateEmitter', () => {
   describe('initialization', () => {
@@ -7,6 +8,13 @@ describe('WorldstateEmitter', () => {
       const ws = await WSEmitter.make();
       expect(ws).to.be.instanceOf(WSEmitter);
       ws.destroy();
+    });
+
+    it('should use a custom logger when provided', async () => {
+      const customLogger = createMockLogger()._withCapture();
+      const ws = await WSEmitter.make({ features: ['worldstate'], logger: customLogger as never });
+      ws.destroy();
+      expect(customLogger._logs.some((entry) => entry.level === 'debug')).to.equal(true);
     });
 
     it('should create emitter with specific locale', async () => {

--- a/utilities/Cache.ts
+++ b/utilities/Cache.ts
@@ -2,6 +2,7 @@ import { EventEmitter } from 'node:events';
 
 import type { CronJob as CronJobType } from 'cron';
 import { CronJob } from 'cron';
+import type { Logger } from 'winston';
 
 import { logger } from '@/utilities';
 
@@ -22,8 +23,8 @@ export default class CronCache extends EventEmitter {
    * @param pattern - Optional cron pattern for update frequency
    * @returns Initialized CronCache instance
    */
-  static async make(url: string, pattern?: string): Promise<CronCache> {
-    const cache = new CronCache(url, pattern);
+  static async make(url: string, pattern?: string, uLogger?: Logger): Promise<CronCache> {
+    const cache = new CronCache(url, pattern, uLogger);
     await cache.#update();
     return cache;
   }
@@ -32,11 +33,13 @@ export default class CronCache extends EventEmitter {
    * Create a new CronCache
    * @param url - The URL to fetch data from
    * @param pattern - Optional cron pattern for update frequency
+   * @param uLogger - Optional logger instance
    */
-  constructor(url: string, pattern?: string) {
+  constructor(url: string, pattern?: string, uLogger?: Logger) {
     super();
     this.#url = url;
     if (pattern) this.#pattern = pattern;
+    if (uLogger) this.#logger = uLogger;
     this.#job = new CronJob(this.#pattern, () => void this.#update(), undefined, true);
     this.#job.start();
   }
@@ -72,13 +75,13 @@ export default class CronCache extends EventEmitter {
    * @private
    */
   async #fetch(): Promise<string> {
-    logger.silly(`fetching... ${this.#url}`);
+    this.#logger.silly(`fetching... ${this.#url}`);
     const response = await fetch(this.#url);
 
     if (!response.ok) {
       const responseText = await response.text();
       const errorMessage = `Failed to fetch ${this.#url}: ${response.status} ${response.statusText}`;
-      logger.error(errorMessage, { responseText });
+      this.#logger.error(errorMessage, { responseText });
       throw new Error(errorMessage);
     }
 
@@ -92,14 +95,14 @@ export default class CronCache extends EventEmitter {
    */
   async get(): Promise<string | undefined> {
     if (this.#updating) {
-      logger.silly('returning in-progress update promise');
+      this.#logger.silly('returning in-progress update promise');
       return this.#updating;
     }
     if (!this.#data) {
-      logger.silly('returning new update promise');
+      this.#logger.silly('returning new update promise');
       return this.#update();
     }
-    logger.silly('returning cached data');
+    this.#logger.silly('returning cached data');
     return this.#data;
   }
 

--- a/utilities/WSCache.ts
+++ b/utilities/WSCache.ts
@@ -2,6 +2,7 @@ import type EventEmitter from 'node:events';
 import type { Locale } from 'warframe-worldstate-data';
 import type { Dependency } from 'warframe-worldstate-parser';
 import WorldState from 'warframe-worldstate-parser';
+import type { Logger } from 'winston';
 import { logger } from '@/utilities';
 import type CronCache from '@/utilities/Cache';
 
@@ -10,6 +11,7 @@ interface WSCacheOptions {
   kuvaCache: CronCache;
   sentientCache: CronCache;
   eventEmitter: EventEmitter;
+  logger?: Logger;
 }
 
 interface WorldStateDeps extends Dependency {}
@@ -34,12 +36,13 @@ export default class WSCache {
    * @param options.sentientCache - Cache of sentient outpost data, provided by Semlar
    * @param options.eventEmitter - Emitter to push new worldstate updates to
    */
-  constructor({ language, kuvaCache, sentientCache, eventEmitter }: WSCacheOptions) {
+  constructor({ language, kuvaCache, sentientCache, eventEmitter, logger: uLogger }: WSCacheOptions) {
     this.#inner = undefined;
     this.#kuvaCache = kuvaCache;
     this.#sentientCache = sentientCache;
     this.#language = language;
     this.#emitter = eventEmitter;
+    this.#logger = uLogger || logger;
   }
 
   /**
@@ -52,6 +55,9 @@ export default class WSCache {
       locale: this.#language as Locale,
       kuvaData: [],
       sentientData: undefined,
+      logger: {
+        debug: (message: string) => this.#logger.debug(message),
+      },
     };
     try {
       const kuvaRaw = await this.#kuvaCache.get();
@@ -59,7 +65,7 @@ export default class WSCache {
         deps.kuvaData = JSON.parse(kuvaRaw);
       }
     } catch (err) {
-      logger.debug(`Error parsing kuva data for ${this.#language}: ${err}`);
+      this.#logger.debug(`Error parsing kuva data for ${this.#language}: ${err}`);
     }
     try {
       const sentientRaw = await this.#sentientCache.get();
@@ -67,7 +73,7 @@ export default class WSCache {
         deps.sentientData = JSON.parse(sentientRaw);
       }
     } catch (err) {
-      logger.warn(`Error parsing sentient data for ${this.#language}: ${err}`);
+      this.#logger.warn(`Error parsing sentient data for ${this.#language}: ${err}`);
     }
 
     let t: WorldState | undefined;
@@ -100,7 +106,7 @@ export default class WSCache {
    * @param newData - New string data to parse
    */
   set data(newData: string) {
-    logger.debug(`got new data for ${this.#language}, parsing...`);
+    this.#logger.debug(`got new data for ${this.#language}, parsing...`);
     void this.#update(newData);
   }
 

--- a/utilities/index.ts
+++ b/utilities/index.ts
@@ -1,26 +1,65 @@
 import { createLogger, format, type Logger, transports } from 'winston';
 import { LOG_LEVEL } from '@/utilities/env';
 
-let tempLogger: Logger;
+export enum LogLevel {
+  FATAL = 'fatal',
+  ERROR = 'error',
+  WARN = 'warn',
+  INFO = 'info',
+  DEBUG = 'debug',
+  SILLY = 'silly',
+}
+const levels = {
+  [LogLevel.FATAL]: 0,
+  [LogLevel.ERROR]: 1,
+  [LogLevel.WARN]: 2,
+  [LogLevel.INFO]: 3,
+  [LogLevel.DEBUG]: 4,
+  [LogLevel.SILLY]: 5,
+};
+
+let loggerInstance: Logger;
 try {
   const { combine, label, printf, colorize } = format;
 
   /* Logger setup */
   const transport = new transports.Console();
   const logFormat = printf((info) => `[${info.label}] ${info.level}: ${info.message}`);
-  tempLogger = createLogger({
+  loggerInstance = createLogger({
     format: combine(colorize(), label({ label: 'WS' }), logFormat),
     transports: [transport],
+    level: LOG_LEVEL,
+    levels,
   });
-  tempLogger.level = LOG_LEVEL;
+  loggerInstance.level = LOG_LEVEL;
 } catch (_e) {
   // Fallback to console wrapped as Logger
-  tempLogger = createLogger({
+  loggerInstance = createLogger({
     transports: [new transports.Console()],
+    level: LOG_LEVEL,
+    levels,
   });
 }
 
-export const logger = tempLogger;
+/**
+ * Replace the module-wide logger used by emitter internals.
+ * Call before constructing handlers when injecting a host-provided logger.
+ */
+export const setLogger = (uLogger: Logger): void => {
+  loggerInstance = uLogger;
+};
+
+/** Global logger proxy so existing imports pick up setLogger() overrides. */
+export const logger: Logger = new Proxy({} as Logger, {
+  get(_target, prop) {
+    const value = Reflect.get(loggerInstance, prop, loggerInstance);
+    return typeof value === 'function' ? value.bind(loggerInstance) : value;
+  },
+  set(_target, prop, value) {
+    Reflect.set(loggerInstance, prop, value);
+    return true;
+  },
+});
 
 /**
  * Group an array by a field value


### PR DESCRIPTION
**Summary**

Allow providing a Logger instance to avoid internal-only logger access

---
**Resolves issue**
lack of access to logger level

---
**Screenshots/examples**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Application now supports dependency-injected logging, enabling custom logger instances to be provided during initialization for enhanced control and customization across all handlers and utilities.

* **Tests**
  * Added test coverage for custom logger injection and validation during emitter and cache operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->